### PR TITLE
Fix: Correct swapped width and height attributes in SVG tag

### DIFF
--- a/svglib/svg.py
+++ b/svglib/svg.py
@@ -230,7 +230,7 @@ class SVG:
         viz_elements = self._get_viz_elements(with_points, with_handles, with_bboxes, color_firstlast, with_moves)
         newline = "\n"
         return (
-            f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="{self.viewbox.to_str()}" height="{self.viewbox.wh.x}px" width="{self.viewbox.wh.y}px">'
+            f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="{self.viewbox.to_str()}" height="{self.viewbox.wh.y}px" width="{self.viewbox.wh.x}px">'
             f'{self._markers() if with_markers else ""}'
             f'{newline.join(svg_path_group.to_str(fill=fill, with_markers=with_markers) for svg_path_group in [*self.svg_path_groups, *viz_elements])}'
             '</svg>')


### PR DESCRIPTION
I am very interested in your research. While executing your code line by line, I noticed that during the keypoint detection process, the width and height of a non-square SVG file were swapped. Please take a look and review it.

This PR fixes an issue where the width and height attributes in the SVG tag were mistakenly swapped. Previously, width was assigned to self.viewbox.wh.y, and height was assigned to self.viewbox.wh.x. This was incorrect, as width should correspond to the X-dimension and height to the Y-dimension.

To correct this, the values have been properly reassigned:

width → self.viewbox.wh.x
height → self.viewbox.wh.y